### PR TITLE
Remove ruby version definition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-ruby '>= 2.2.3'
 
 gem 'sinatra'
 gem 'mods_display'


### PR DESCRIPTION
(to allow modern versions of ruby on latest heroku cedar stack)